### PR TITLE
Implement folder picker via native dialog

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,6 +1,8 @@
-import { app, BrowserWindow, shell } from 'electron'
+import { app, BrowserWindow, ipcMain, shell } from 'electron'
 import { join } from 'path'
 import { is } from '@electron-toolkit/utils'
+import { IpcChannels } from '@shared/ipc-channels'
+import { handleSelectFolder } from './ipc-handlers'
 
 function createWindow(): void {
   const mainWindow = new BrowserWindow({
@@ -32,6 +34,8 @@ function createWindow(): void {
 }
 
 app.whenReady().then(() => {
+  ipcMain.handle(IpcChannels.SELECT_FOLDER, handleSelectFolder)
+
   createWindow()
 
   app.on('activate', () => {

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1,0 +1,9 @@
+import { BrowserWindow, dialog } from 'electron'
+
+export async function handleSelectFolder(): Promise<string | null> {
+  const window = BrowserWindow.getFocusedWindow()
+  const result = await dialog.showOpenDialog(window!, {
+    properties: ['openDirectory']
+  })
+  return result.canceled ? null : result.filePaths[0]
+}

--- a/tests/vitest/main/select-folder.test.ts
+++ b/tests/vitest/main/select-folder.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('electron', () => ({
+  dialog: {
+    showOpenDialog: vi.fn()
+  },
+  BrowserWindow: {
+    getFocusedWindow: vi.fn(() => ({}))
+  }
+}))
+
+import { dialog } from 'electron'
+import { handleSelectFolder } from '../../../src/main/ipc-handlers'
+
+describe('handleSelectFolder', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns folder path when user selects one', async () => {
+    vi.mocked(dialog.showOpenDialog).mockResolvedValue({
+      canceled: false,
+      filePaths: ['/Users/test/Documents']
+    })
+
+    const result = await handleSelectFolder()
+
+    expect(result).toBe('/Users/test/Documents')
+  })
+
+  it('returns null when user cancels', async () => {
+    vi.mocked(dialog.showOpenDialog).mockResolvedValue({
+      canceled: true,
+      filePaths: []
+    })
+
+    const result = await handleSelectFolder()
+
+    expect(result).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `ipcMain.handle` for `SELECT_FOLDER` channel — opens native macOS folder picker
- Extracts handler logic to `src/main/ipc-handlers.ts` for testability (avoids importing the full Electron entry point in tests)
- Adds unit tests with mocked `electron.dialog`

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run test` passes (12/12, including 2 new handler tests)
- [ ] `npm run dev` → click "Open Folder" → native dialog appears → select folder → HomeView shows scanned path
- [ ] Cancel dialog → no error, stays on welcome screen

Fixes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)