### PR TITLE
Add rescan button to rootbar

### DIFF
--- a/src/renderer/src/views/HomeView.vue
+++ b/src/renderer/src/views/HomeView.vue
@@ -53,6 +53,11 @@ function findParent(node: FileNode, targetPath: string): FileNode | null {
   return null
 }
 
+function rescan(): void {
+  if (!scanStore.rootNode || scanStore.isScanning) return
+  scanStore.scan(scanStore.rootNode.path)
+}
+
 const hoveredPath = ref<string | null>(null)
 
 function onHover(node: FileNode | null): void {
@@ -114,6 +119,7 @@ async function openInTerminal(node?: FileNode): Promise<void> {
     </div>
     <div v-else-if="viewRoot" class="viz-container">
       <div class="viz-rootbar">
+        <button class="toolbar-button" :disabled="scanStore.isScanning" @click="rescan">Rescan</button>
         <button v-if="isDrilledIn" class="toolbar-button" @click="goUp">Up</button>
         <span class="viz-path">{{ viewRoot.path }}</span>
       </div>
@@ -246,8 +252,13 @@ async function openInTerminal(node?: FileNode): Promise<void> {
   transition: background 0.15s;
 }
 
-.toolbar-button:hover {
+.toolbar-button:hover:not(:disabled) {
   background: #3a3a5a;
+}
+
+.toolbar-button:disabled {
+  opacity: 0.4;
+  cursor: default;
 }
 
 .toolbar-button--primary {


### PR DESCRIPTION
## Summary
- Adds a "Rescan" button to the rootbar that re-scans the original root directory using the existing `scan()` store action
- Button is disabled while a scan is in progress
- Adds disabled styling for toolbar buttons

Fixes #23

## Test plan
- [x] Open a folder, verify Rescan button appears in rootbar
- [x] Click Rescan — data refreshes, drill-down state resets to root
- [x] Button is disabled during scan
- [x] Existing tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)