### PR TITLE
Add macOS packaging script and configure icon

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -11,6 +11,8 @@ files:
   - "!{tsconfig.json,tsconfig.node.json,tsconfig.web.json}"
 asar: true
 mac:
+  icon: icon.icon
+  identity: null
   target:
     - dmg
     - zip

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json",
     "typecheck:web": "vue-tsc --noEmit -p tsconfig.web.json",
     "typecheck": "npm run typecheck:node && npm run typecheck:web",
+    "package": "electron-vite build && electron-builder --mac",
     "test": "vitest run",
     "test:watch": "vitest"
   },


### PR DESCRIPTION
- Add `npm run package` script (electron-vite build + electron-builder)
- Set mac.icon to icon.icon so electron-builder compiles the Icon Composer asset into an asset catalog
- Skip code signing for now (identity: null) for local builds