### PR TITLE
Upgrade Electron 41 → 43

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,8 +54,9 @@ Two IPC patterns are in use:
 
 ### Known Electron quirks (macOS)
 
-- **`representedObject is not a WeakPtrToElectronMenuModelAsNSObject`** — Console warning triggered by clicking the Window menu. This is an upstream Electron/Cocoa menu integration issue, not caused by our code. Harmless (no functional impact). See [electron/electron#23778](https://github.com/electron/electron/pull/23778) for related context. Will resolve with a future Electron update — no action needed on our side.
-- **`[DEP0180] fs.Stats constructor is deprecated`** — One-time deprecation warning from Node.js internals when `lstat` is called during directory scanning. Upstream Electron/Node issue, not caused by our code. Harmless — will resolve with a future Electron update.
+Currently none. Two previously documented harmless console warnings (`representedObject`/WeakPtr on Window-menu clicks, `[DEP0180] fs.Stats constructor is deprecated` during scans) were resolved upstream and are gone as of the Electron 43 upgrade (issue #43) — don't re-add them from older notes.
+
+Since Electron 42, the npm package no longer downloads the binary via `postinstall`; after a fresh `npm ci` run `npx install-electron` (the binary otherwise downloads on demand at first launch).
 
 ## Conventions
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@vitejs/plugin-vue": "^6.0.4",
         "@vue/test-utils": "^2.4.6",
         "d3": "^7.9.0",
-        "electron": "^41.0.0",
+        "electron": "^43.1.0",
         "electron-builder": "^26.8.1",
         "electron-vite": "^5.0.0",
         "jsdom": "^28.1.0",
@@ -4527,11 +4527,10 @@
       }
     },
     "node_modules/electron": {
-      "version": "41.10.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-41.10.1.tgz",
-      "integrity": "sha512-8BGbTyMWNCXZ2nErXqchO31CJsHlzD5joOiWbNerBi1EnGLXkiMEF3yUUN+T16duz3XYwLTcxOq38MMcWf0sQA==",
+      "version": "43.1.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-43.1.0.tgz",
+      "integrity": "sha512-DPfxpQLd4NL3BJ8DBxYAfmLUKKesF5Rx9dQx5FyczAP8bhOPScjHE48GArVeXu68LlAainuwkmQTQvdZwpIIAQ==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@electron-internal/extract-zip": "^1.0.1",
@@ -4539,7 +4538,8 @@
         "@types/node": "^24.9.0"
       },
       "bin": {
-        "electron": "cli.js"
+        "electron": "cli.js",
+        "install-electron": "install.js"
       },
       "engines": {
         "node": ">= 22.12.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@vitejs/plugin-vue": "^6.0.4",
     "@vue/test-utils": "^2.4.6",
     "d3": "^7.9.0",
-    "electron": "^41.0.0",
+    "electron": "^43.1.0",
     "electron-builder": "^26.8.1",
     "electron-vite": "^5.0.0",
     "jsdom": "^28.1.0",


### PR DESCRIPTION
Fixes #43

## What

Bumps `electron` `^41.0.0` → `^43.1.0` (Chromium 150, Node 24.18.0) on its own branch, per the issue.

## Research summary

- **Current stable verified** against npm dist-tags / releases.electronjs.org: 43.1.0 (published 2026-07-07 — passes the 3-day `min-release-age` cooldown).
- **Breaking changes 42 + 43 reviewed:** none affect our code. Only touchpoint: `dialog.showOpenDialog` (folder picker) now defaults to the Downloads directory instead of the OS-remembered one — cosmetic, no `defaultPath` logic on our side.
- **Since Electron 42 the npm package no longer downloads the binary via `postinstall`** — after fresh installs run `npx install-electron` (documented in CLAUDE.md).
- **Tooling compat:** electron-vite 5.0.0 (no Electron peer constraint), electron-builder already at 26.15.3, `@types/node` already 24.x transitively, local Node 26 ≥ required 22.12.

## Verified

- `npm run typecheck` ✅ (node + web)
- `npm test` ✅ 110/110
- `npm run build` ✅
- Dev app launches cleanly on 43.1.0 (full process tree, no console warnings at startup)
- Both known-harmless console warnings are **gone**: the `representedObject`/WeakPtr menu warning was fixed upstream in electron/electron#50608, and the `DEP0180` fs.Stats deprecation (electron/electron#47390) no longer reproduces — probed `lstat` directly in an Electron 43 main process, clean stderr. CLAUDE.md's "Known Electron quirks" section updated.

## Manual smoke test (please run before merging)

`npm run dev`, then:

- [x] Folder picker opens and selects (note: now starts in Downloads — expected)
- [x] Full scan of a large directory completes with progress updates
- [x] Treemap renders + drill-down works
- [x] Context menu: "Reveal in File Manager" and "Open Terminal Here"
- [x] Light/dark switch
- [x] Keyboard navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)