### PR TITLE
Show build identity (git SHA + build time) in the About panel

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -79,6 +79,10 @@ A lightweight desktop app that scans a local directory and presents an interacti
 
 - **Scan progress:** Main process streams live progress (file count + current path) to renderer via `webContents.send()` push channel, throttled with a generic `makeThrottled` utility. Renderer shows a semi-transparent overlay during scan (blocking interaction with stale data). The `isDestroyed()` guard on the sender prevents crashes when the window closes mid-scan.
 
+## Resolved Decisions (Step 6)
+
+- **Build identity over version-bump conventions (issue #49):** To tell which build is running during smoke tests, the About panel's parenthesized slot (`CFBundleVersion`) carries `git describe --always --dirty` plus a build timestamp, injected at build time via `define` in `electron.vite.config.ts` and applied with `app.setAboutPanelOptions()`. Packaged builds also set electron-builder's `buildVersion`. A convention of manually bumping the patch version per PR was considered and rejected: discipline-dependent, and its carveouts make the signal untrustworthy exactly when it's needed. Semver bumps remain reserved for meaningful releases.
+
 ## Open Questions
 
 (none currently)

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -1,10 +1,31 @@
 import { resolve } from 'path'
+import { execSync } from 'child_process'
 import { defineConfig, externalizeDepsPlugin } from 'electron-vite'
 import vue from '@vitejs/plugin-vue'
+
+// Build identity for the About panel (issue #49). Evaluated once per
+// electron-vite invocation: dev-server start in dev, the build step when packaging.
+function gitDescribe(): string {
+  try {
+    return execSync('git describe --always --dirty', { encoding: 'utf8' }).trim()
+  } catch {
+    return 'unknown'
+  }
+}
+
+function localTimestamp(): string {
+  const now = new Date()
+  const pad = (n: number): string => String(n).padStart(2, '0')
+  return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())} ${pad(now.getHours())}:${pad(now.getMinutes())}`
+}
 
 export default defineConfig({
   main: {
     plugins: [externalizeDepsPlugin()],
+    define: {
+      __GIT_SHA__: JSON.stringify(gitDescribe()),
+      __BUILD_TIME__: JSON.stringify(localTimestamp())
+    },
     resolve: {
       alias: {
         '@shared': resolve('src/shared')

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json",
     "typecheck:web": "vue-tsc --noEmit -p tsconfig.web.json",
     "typecheck": "npm run typecheck:node && npm run typecheck:web",
-    "package": "electron-vite build && electron-builder --mac",
+    "package": "electron-vite build && electron-builder --mac -c.buildVersion=\"$(git describe --always --dirty)\"",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/src/main/build-info.d.ts
+++ b/src/main/build-info.d.ts
@@ -1,0 +1,3 @@
+// Injected at build time via `define` in electron.vite.config.ts (issue #49)
+declare const __GIT_SHA__: string
+declare const __BUILD_TIME__: string

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -40,6 +40,15 @@ function createWindow(): void {
 }
 
 app.whenReady().then(() => {
+  // Build identity in "Out Of Space" → "About": marketing version plus
+  // git describe + build time in the parenthesized CFBundleVersion slot,
+  // so a smoke tester can tell which build is running (issue #49)
+  app.setAboutPanelOptions({
+    applicationName: 'Out Of Space',
+    applicationVersion: app.getVersion(),
+    version: `${__GIT_SHA__}, built ${__BUILD_TIME__}`
+  })
+
   ipcMain.handle(IpcChannels.SELECT_FOLDER, handleSelectFolder)
   ipcMain.handle(IpcChannels.SCAN_FOLDER, handleScanFolder)
   ipcMain.handle(IpcChannels.SHOW_IN_FINDER, handleShowInFinder)


### PR DESCRIPTION
Fixes #49

## What

The macOS About panel now identifies the exact build: **`0.1.0 (e4c4eb8-dirty, built 2026-07-12 18:40)`** instead of `0.1.0 (0.1.0)`. No manual discipline required — values are stamped automatically at build time.

## How

- **`electron.vite.config.ts`:** injects `__GIT_SHA__` (`git describe --always --dirty`) and `__BUILD_TIME__` (local time, minute precision) into the main-process bundle via `define`. Evaluated once per electron-vite invocation: dev-server start in dev, the build step when packaging.
- **`src/main/index.ts`:** `app.setAboutPanelOptions()` puts them in the About panel's parenthesized `CFBundleVersion` slot; also sets `applicationName: 'Out Of Space'` so the dev About panel stops saying "out-of-space".
- **`package.json`:** the `package` script passes `-c.buildVersion="$(git describe --always --dirty)"` to electron-builder so the packaged Info.plist's `CFBundleVersion` carries the SHA too. **Correction to an earlier claim here:** Finder's Get Info / column-view "Version" field displays only `CFBundleShortVersionString` (`0.1.0`) — macOS never surfaces `CFBundleVersion` in Finder, so it will *not* "agree with the app" there. The plist stamp is still worthwhile: it's the canonical build-identity slot (crash reports, `defaults read`/PlistBuddy, and the About panel of a packaged build even without the runtime override). To check it: `/usr/libexec/PlistBuddy -c 'Print CFBundleVersion' "dist/mac-arm64/Out Of Space.app/Contents/Info.plist"`.
- **`src/main/build-info.d.ts`:** ambient declarations for the injected constants.
- **`DESIGN.md`:** records the decision, including why the manual per-PR patch-bump convention was rejected.

## Verified

- `npm run typecheck` ✅ (node + web), `npm test` ✅ 110/110, `npm run build` ✅
- Built bundle contains the injected values (checked `out/main/index.js`); `-dirty` suffix correctly appears for an uncommitted tree
- App launches cleanly with the About-panel call in place
- `npm run package` on a clean tree stamps `CFBundleVersion = 9150224` (current HEAD) into the packaged Info.plist — verified with PlistBuddy

## Smoke check for you

`npm run dev` → menu "Out Of Space" → "About Out Of Space" should show the version line with SHA + timestamp matching your dev-server start time. Optionally `npm run package` and check the packaged app's About panel (not Finder Get Info — see correction above). Note that anything already sitting in `dist/` predates this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
