### PR TITLE
Bump TypeScript 5.9 → 6.0 (migration bridge toward TS 7)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "electron-vite": "^5.0.0",
         "jsdom": "^29.1.1",
         "pinia": "^3.0.4",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "vite": "^7.3.1",
         "vitest": "^4.1.0",
         "vue": "^3.5.30",
@@ -7489,9 +7489,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "electron-vite": "^5.0.0",
     "jsdom": "^29.1.1",
     "pinia": "^3.0.4",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vite": "^7.3.1",
     "vitest": "^4.1.0",
     "vue": "^3.5.30",


### PR DESCRIPTION
Relates to microsoft/typescript-go#45 (does not close it — the 6 → 7 step remains, blocked on vue-tsc/tsgo upstream)

## What

Bumps `typescript` `^5.9.3` → `^6.0.3` (published 2026-04-16, well past the release cooldown). TS 6.0 is the official migration bridge: it type-checks with TS 7 semantics while still running on the JS compiler, so when vue-tsc gains native-compiler support the 7.0 jump becomes mechanical.

## Verified

- `npm run typecheck` ✅ both contexts (`tsc` node + `vue-tsc` web), **zero new diagnostics**
- `npm test` ✅ 110/110
- `npm run build` ✅

Typecheck-only dependency (esbuild/electron-vite does all transpilation), so there's no runtime surface — no manual smoke test needed.

## Context

The TS 7 canary (see microsoft/typescript-go#45 comments) confirmed vue-tsc 3.3.7 crashes under TS 7 (`ERR_PACKAGE_PATH_NOT_EXPORTED`). Upstream, real tsgo integration is actively worked but blocked on the API planned for TS 7.1 (microsoft/TypeScript#63800), with an interop layer being explored in the meantime — so the remaining step is watched, just not shippable yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)