### PR TITLE
Add Playwright end-to-end smoke suite for the assembled app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ jobs:
   typecheck-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm
@@ -21,14 +21,14 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm
       # Electron ≥42 no longer downloads its binary via postinstall;
       # install-electron fetches it into this cache explicitly
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: ~/Library/Caches/electron
           key: electron-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -37,7 +37,7 @@ jobs:
       - run: npx install-electron
       # Playwright drives Electron's bundled Chromium — no browser download
       - run: npm run test:e2e
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: playwright-results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,17 +26,25 @@ jobs:
         with:
           node-version: 24
           cache: npm
+      # Key the binary cache on the Electron version itself, so dependency
+      # bumps that don't touch Electron reuse the entry instead of re-saving
+      # ~100 MB per lockfile change
+      - id: electron-version
+        run: echo "v=$(node -p "require('./package-lock.json').packages['node_modules/electron'].version")" >> "$GITHUB_OUTPUT"
       # Electron ≥42 no longer downloads its binary via postinstall;
       # install-electron fetches it into this cache explicitly
       - uses: actions/cache@v6
         with:
           path: ~/Library/Caches/electron
-          key: electron-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
-          restore-keys: electron-${{ runner.os }}-
+          key: electron-${{ runner.os }}-${{ steps.electron-version.outputs.v }}
       - run: npm ci
       - run: npx install-electron
-      # Playwright drives Electron's bundled Chromium — no browser download
+      # Playwright drives Electron's bundled Chromium — no browser download.
+      # Always record a trace: smoke-trace.zip lands in test-results/, which
+      # uploads on failure — the only replayable diagnostic for CI-only failures
       - run: npm run test:e2e
+        env:
+          OOS_E2E_TRACE: 1
       - uses: actions/upload-artifact@v7
         if: failure()
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Typecheck & Test
+name: CI
 
 on:
   pull_request:

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -16,3 +16,30 @@ jobs:
       - run: npm ci
       - run: npm run typecheck
       - run: npm run test
+
+  e2e:
+    runs-on: macos-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      # Electron ≥42 no longer downloads its binary via postinstall;
+      # install-electron fetches it into this cache explicitly
+      - uses: actions/cache@v4
+        with:
+          path: ~/Library/Caches/electron
+          key: electron-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: electron-${{ runner.os }}-
+      - run: npm ci
+      - run: npx install-electron
+      # Playwright drives Electron's bundled Chromium — no browser download
+      - run: npm run test:e2e
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-results
+          path: test-results/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ out/
 .DS_Store
 *.log
 notes/
+test-results/
+playwright-report/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,3 +99,12 @@ We use **GitHub Issues** (via `gh`) as the shared backlog.
 - **Run:** `npm test` (single run), `npm run test:watch` (watch mode)
 - **Mocking `window.api`:** Use `vi.stubGlobal('api', mockApi)` in renderer tests
 - **Pinia in tests:** `setActivePinia(createPinia())` in `beforeEach` — no `@pinia/testing` needed
+
+### End-to-end (Playwright, issue #53)
+
+- **Location:** `tests/playwright/` — Playwright's Electron driver against the built app (`out/`)
+- **Run:** `npm run test:e2e` (builds first; launches the real app window locally — brief focus steal is expected)
+- **Fixture:** the scanned tree is generated at test setup into a temp dir (deterministic sizes; nothing committed)
+- **Native dialog:** `dialog.showOpenDialog` is stubbed inside the main process via `electronApp.evaluate()` — the only seam Playwright can't drive; everything downstream (IPC, scanner, rendering) is real
+- **Flake budget — scope discipline:** this suite stays at smoke level: boot + a few core flows over a deterministic fixture, its only job being "the assembled app works". Logic and component testing belong in Vitest — do not grow this into a second component suite, and keep `retries: 0` so flakes surface as failures to fix rather than being retried away.
+- **Known coupling:** Playwright's Electron driver occasionally lags a new Electron major — if an Electron bump PR fails only in the e2e job, suspect that before a real regression.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,5 +106,6 @@ We use **GitHub Issues** (via `gh`) as the shared backlog.
 - **Run:** `npm run test:e2e` (builds first; launches the real app window locally — brief focus steal is expected)
 - **Fixture:** the scanned tree is generated at test setup into a temp dir (deterministic sizes; nothing committed)
 - **Native dialog:** `dialog.showOpenDialog` is stubbed inside the main process via `electronApp.evaluate()` — the only seam Playwright can't drive; everything downstream (IPC, scanner, rendering) is real
+- **Watching a run:** `OOS_E2E_TRACE=1 npm run test:e2e` records a trace; `npx playwright show-trace test-results/smoke-trace.zip` replays it step by step with screenshots and DOM snapshots. For live stepping, `npx playwright test --debug` opens the Inspector (`slowMo` is not supported by the Electron driver).
 - **Flake budget — scope discipline:** this suite stays at smoke level: boot + a few core flows over a deterministic fixture, its only job being "the assembled app works". Logic and component testing belong in Vitest — do not grow this into a second component suite, and keep `retries: 0` so flakes surface as failures to fix rather than being retried away.
 - **Known coupling:** Playwright's Electron driver occasionally lags a new Electron major — if an Electron bump PR fails only in the e2e job, suspect that before a real regression.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -83,6 +83,10 @@ A lightweight desktop app that scans a local directory and presents an interacti
 
 - **Build identity over version-bump conventions (issue #49):** To tell which build is running during smoke tests, the About panel's parenthesized slot (`CFBundleVersion`) carries `git describe --always --dirty` plus a build timestamp, injected at build time via `define` in `electron.vite.config.ts` and applied with `app.setAboutPanelOptions()`. Packaged builds also set electron-builder's `buildVersion`. A convention of manually bumping the patch version per PR was considered and rejected: discipline-dependent, and its carveouts make the signal untrustworthy exactly when it's needed. Semver bumps remain reserved for meaningful releases.
 
+## Resolved Decisions (Step 7)
+
+- **End-to-end smoke suite (issue #53):** Playwright's Electron driver launches the built app and exercises the wiring the Vitest/jsdom suite can't see: preload contextBridge, main↔renderer IPC round-trips, boot of the built output, and real Chromium rendering of the D3 treemap — the regression class dependency-bump PRs introduce while unit tests stay green. Deliberately smoke-scoped (flake budget): boot plus a few core flows over a generated fixture tree, no retries, logic/component coverage stays in Vitest. The native folder dialog is stubbed in the main process (`electronApp.evaluate()`) — the one seam Playwright can't drive. CI runs it on `macos-latest` (the shipping target, no xvfb needed). A renderer-only variant (browser + mocked `window.api`) was considered and rejected: it mostly duplicates component-test coverage while missing the integration layer that motivates the suite.
+
 ## Open Questions
 
 (none currently)

--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ npm run dev
 # Type check
 npm run typecheck
 
+# Unit/component tests (Vitest)
+npm test
+
+# End-to-end smoke tests (Playwright, launches the built app)
+npm run test:e2e
+
 # Production build
 npm run build
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "license": "MIT",
       "devDependencies": {
         "@electron-toolkit/utils": "^4.0.0",
+        "@playwright/test": "^1.61.1",
         "@types/d3": "^7.4.3",
         "@vitejs/plugin-vue": "^6.0.4",
         "@vue/test-utils": "^2.4.6",
@@ -1604,6 +1605,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -6527,6 +6544,53 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/plist": {

--- a/package.json
+++ b/package.json
@@ -16,10 +16,12 @@
     "typecheck": "npm run typecheck:node && npm run typecheck:web",
     "package": "electron-vite build && electron-builder --mac -c.buildVersion=\"$(git describe --always --dirty)\"",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "electron-vite build && playwright test"
   },
   "devDependencies": {
     "@electron-toolkit/utils": "^4.0.0",
+    "@playwright/test": "^1.61.1",
     "@types/d3": "^7.4.3",
     "@vitejs/plugin-vue": "^6.0.4",
     "@vue/test-utils": "^2.4.6",

--- a/package.json
+++ b/package.json
@@ -13,11 +13,12 @@
     "postinstall": "electron-builder install-app-deps",
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json",
     "typecheck:web": "vue-tsc --noEmit -p tsconfig.web.json",
-    "typecheck": "npm run typecheck:node && npm run typecheck:web",
+    "typecheck:e2e": "tsc --noEmit -p tests/playwright",
+    "typecheck": "npm run typecheck:node && npm run typecheck:web && npm run typecheck:e2e",
     "package": "electron-vite build && electron-builder --mac -c.buildVersion=\"$(git describe --always --dirty)\"",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:e2e": "electron-vite build && playwright test"
+    "test:e2e": "npm run build && playwright test"
   },
   "devDependencies": {
     "@electron-toolkit/utils": "^4.0.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from '@playwright/test'
+
+// E2E smoke suite for the assembled Electron app (issue #53).
+// Run `npm run test:e2e` — the built app in out/ must be current, so the
+// script builds first. No browser download needed: Playwright drives
+// Electron's own Chromium.
+export default defineConfig({
+  testDir: 'tests/playwright',
+  timeout: 30_000,
+  // One Electron instance at a time; the suite is a single serial journey
+  workers: 1,
+  fullyParallel: false,
+  // No retries by design: the suite is small and deterministic, so flakes
+  // should surface as failures to fix, not be retried away
+  retries: 0,
+  reporter: [['list']],
+  outputDir: 'test-results'
+})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,7 +9,8 @@ export default defineConfig({
   timeout: 30_000,
   // One Electron instance at a time; the suite is a single serial journey
   workers: 1,
-  fullyParallel: false,
+  // A stray committed test.only must fail CI, not silently shrink the suite
+  forbidOnly: !!process.env.CI,
   // No retries by design: the suite is small and deterministic, so flakes
   // should surface as failures to fix, not be retried away
   retries: 0,

--- a/tests/playwright/helpers/fixture-tree.ts
+++ b/tests/playwright/helpers/fixture-tree.ts
@@ -1,0 +1,43 @@
+import { mkdtemp, mkdir, writeFile, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+export interface FixtureTree {
+  /** Absolute path of the generated tree's root directory */
+  root: string
+  cleanup(): Promise<void>
+}
+
+/**
+ * Generates a small directory tree with deterministic file sizes for the
+ * e2e suite to scan. Generated (not committed) so sizes are exact on every
+ * platform — committed fixtures risk eol mangling, and git can't represent
+ * empty directories anyway.
+ *
+ * Sizes are chosen so the two largest files always get labelled treemap
+ * rects at the default 1200×800 window, and so relative rect areas are
+ * unambiguous (400 KB vs 150 KB).
+ */
+export async function createFixtureTree(): Promise<FixtureTree> {
+  const root = await mkdtemp(join(tmpdir(), 'oos-e2e-'))
+
+  const files: Array<[string, number]> = [
+    ['videos/big-video.mp4', 400_000],
+    ['photos/photo-a.raw', 150_000],
+    ['photos/photo-b.raw', 100_000],
+    ['documents/report.pdf', 50_000],
+    ['documents/notes.txt', 10_000],
+    ['small.txt', 1_000]
+  ]
+
+  for (const [relPath, size] of files) {
+    const abs = join(root, relPath)
+    await mkdir(join(abs, '..'), { recursive: true })
+    await writeFile(abs, Buffer.alloc(size, 'a'))
+  }
+
+  return {
+    root,
+    cleanup: () => rm(root, { recursive: true, force: true })
+  }
+}

--- a/tests/playwright/helpers/launch.ts
+++ b/tests/playwright/helpers/launch.ts
@@ -1,0 +1,34 @@
+import { _electron as electron, type ElectronApplication, type Page } from '@playwright/test'
+
+export interface LaunchedApp {
+  app: ElectronApplication
+  page: Page
+}
+
+/**
+ * Launches the built app (out/main/index.js via package.json "main") and
+ * returns the first window. Requires a prior `electron-vite build` — the
+ * `test:e2e` npm script takes care of that.
+ */
+export async function launchApp(): Promise<LaunchedApp> {
+  // ELECTRON_RUN_AS_NODE leaks into the environment when tests run from a
+  // VSCode-spawned terminal and would make Electron start as plain Node
+  const env = { ...process.env } as Record<string, string>
+  delete env['ELECTRON_RUN_AS_NODE']
+
+  const app = await electron.launch({ args: ['.'], env })
+  const page = await app.firstWindow()
+  return { app, page }
+}
+
+/**
+ * Replaces the native folder picker inside the main process — the one seam
+ * Playwright cannot drive — so that the next "Open Folder" click resolves
+ * to `folderPath`. Everything downstream (IPC, scanner, progress events,
+ * rendering) stays real.
+ */
+export async function stubFolderDialog(app: ElectronApplication, folderPath: string): Promise<void> {
+  await app.evaluate(({ dialog }, path) => {
+    dialog.showOpenDialog = async () => ({ canceled: false, filePaths: [path] })
+  }, folderPath)
+}

--- a/tests/playwright/smoke.spec.ts
+++ b/tests/playwright/smoke.spec.ts
@@ -13,12 +13,23 @@ let app: ElectronApplication
 let page: Page
 let fixture: FixtureTree
 
+// OOS_E2E_TRACE=1 records a Playwright trace of the whole journey —
+// step-by-step timeline with before/after screenshots and DOM snapshots.
+// Inspect with: npx playwright show-trace test-results/smoke-trace.zip
+const TRACE = !!process.env['OOS_E2E_TRACE']
+
 test.beforeAll(async () => {
   fixture = await createFixtureTree()
   ;({ app, page } = await launchApp())
+  if (TRACE) {
+    await app.context().tracing.start({ screenshots: true, snapshots: true, title: 'smoke journey' })
+  }
 })
 
 test.afterAll(async () => {
+  if (TRACE && app) {
+    await app.context().tracing.stop({ path: 'test-results/smoke-trace.zip' })
+  }
   await app?.close()
   await fixture?.cleanup()
 })

--- a/tests/playwright/smoke.spec.ts
+++ b/tests/playwright/smoke.spec.ts
@@ -1,5 +1,6 @@
 import { join } from 'path'
 import { test, expect, type ElectronApplication, type Page } from '@playwright/test'
+import type { ElectronApi } from '../../src/shared/types'
 import { createFixtureTree, type FixtureTree } from './helpers/fixture-tree'
 import { launchApp, stubFolderDialog } from './helpers/launch'
 
@@ -28,7 +29,9 @@ test.beforeAll(async () => {
 
 test.afterAll(async () => {
   if (TRACE && app) {
-    await app.context().tracing.stop({ path: 'test-results/smoke-trace.zip' })
+    // The context may already be gone (app crash mid-journey) — a failed
+    // trace save must not block app.close() and fixture.cleanup() below
+    await app.context().tracing.stop({ path: 'test-results/smoke-trace.zip' }).catch(() => {})
   }
   await app?.close()
   await fixture?.cleanup()
@@ -36,9 +39,11 @@ test.afterAll(async () => {
 
 test.afterEach(async ({}, testInfo) => {
   if (testInfo.status !== testInfo.expectedStatus && page) {
-    const path = testInfo.outputPath('failure.png')
-    await page.screenshot({ path }).catch(() => {})
-    testInfo.attachments.push({ name: 'screenshot', path, contentType: 'image/png' })
+    try {
+      await testInfo.attach('screenshot', { body: await page.screenshot(), contentType: 'image/png' })
+    } catch {
+      // Page may be gone (app crash) — nothing to attach
+    }
   }
 })
 
@@ -48,6 +53,18 @@ test('boots the built app to the welcome screen', async () => {
   await expect(page.getByRole('button', { name: 'Open Folder' })).toBeVisible()
 })
 
+// Compile-time-exhaustive mirror of the bridge contract: adding, removing,
+// or renaming a method on ElectronApi without updating this map fails
+// typecheck instead of surfacing minutes into the CI e2e job
+const EXPECTED_API: Record<keyof ElectronApi, 'function'> = {
+  selectFolder: 'function',
+  scanFolder: 'function',
+  showInFinder: 'function',
+  openInTerminal: 'function',
+  onScanProgress: 'function',
+  offScanProgress: 'function'
+}
+
 test('preload bridge exposes the typed api', async () => {
   const apiShape = await page.evaluate(() => {
     const api = (window as { api?: Record<string, unknown> }).api
@@ -56,14 +73,11 @@ test('preload bridge exposes the typed api', async () => {
       .sort()
       .map((key) => `${key}:${typeof api[key]}`)
   })
-  expect(apiShape).toEqual([
-    'offScanProgress:function',
-    'onScanProgress:function',
-    'openInTerminal:function',
-    'scanFolder:function',
-    'selectFolder:function',
-    'showInFinder:function'
-  ])
+  expect(apiShape).toEqual(
+    Object.keys(EXPECTED_API)
+      .sort()
+      .map((key) => `${key}:function`)
+  )
 })
 
 test('scans a folder and renders the treemap', async () => {

--- a/tests/playwright/smoke.spec.ts
+++ b/tests/playwright/smoke.spec.ts
@@ -1,0 +1,116 @@
+import { join } from 'path'
+import { test, expect, type ElectronApplication, type Page } from '@playwright/test'
+import { createFixtureTree, type FixtureTree } from './helpers/fixture-tree'
+import { launchApp, stubFolderDialog } from './helpers/launch'
+
+// One app instance, one user journey: each test picks up the UI state the
+// previous one left behind (welcome → scanned → selected → drilled). Serial
+// mode makes that explicit — a failure skips the rest instead of producing
+// misleading follow-on failures.
+test.describe.configure({ mode: 'serial' })
+
+let app: ElectronApplication
+let page: Page
+let fixture: FixtureTree
+
+test.beforeAll(async () => {
+  fixture = await createFixtureTree()
+  ;({ app, page } = await launchApp())
+})
+
+test.afterAll(async () => {
+  await app?.close()
+  await fixture?.cleanup()
+})
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status !== testInfo.expectedStatus && page) {
+    const path = testInfo.outputPath('failure.png')
+    await page.screenshot({ path }).catch(() => {})
+    testInfo.attachments.push({ name: 'screenshot', path, contentType: 'image/png' })
+  }
+})
+
+test('boots the built app to the welcome screen', async () => {
+  await expect(page).toHaveTitle('Out Of Space')
+  await expect(page.locator('header h1')).toHaveText('Out Of Space')
+  await expect(page.getByRole('button', { name: 'Open Folder' })).toBeVisible()
+})
+
+test('preload bridge exposes the typed api', async () => {
+  const apiShape = await page.evaluate(() => {
+    const api = (window as { api?: Record<string, unknown> }).api
+    if (!api) return null
+    return Object.keys(api)
+      .sort()
+      .map((key) => `${key}:${typeof api[key]}`)
+  })
+  expect(apiShape).toEqual([
+    'offScanProgress:function',
+    'onScanProgress:function',
+    'openInTerminal:function',
+    'scanFolder:function',
+    'selectFolder:function',
+    'showInFinder:function'
+  ])
+})
+
+test('scans a folder and renders the treemap', async () => {
+  await stubFolderDialog(app, fixture.root)
+  await page.getByRole('button', { name: 'Open Folder' }).click()
+
+  await expect(page.locator('.rootbar-prefix')).toHaveText(fixture.root)
+  await expect(page.locator('g.treemap-node text', { hasText: 'big-video.mp4' })).toBeVisible()
+  await expect(page.locator('g.treemap-node text', { hasText: 'photo-a.raw' })).toBeVisible()
+  expect(await page.locator('g.treemap-node').count()).toBeGreaterThan(3)
+})
+
+test('rect areas are proportional to file sizes', async () => {
+  const rectArea = async (label: string): Promise<number> => {
+    const box = await page
+      .locator('g.treemap-node')
+      .filter({ hasText: label })
+      .locator('rect')
+      .first()
+      .boundingBox()
+    expect(box, `bounding box for ${label}`).not.toBeNull()
+    return box!.width * box!.height
+  }
+
+  // 400 KB vs 150 KB — treemap area is proportional to file size
+  expect(await rectArea('big-video.mp4')).toBeGreaterThan(await rectArea('photo-a.raw'))
+})
+
+test('clicking a node selects it and the status bar shows its path', async () => {
+  await page.locator('g.treemap-node').filter({ hasText: 'big-video.mp4' }).click()
+
+  await expect(page.locator('g.treemap-node.selected')).toContainText('big-video.mp4')
+  // Mouse still hovers the node after the click, so the status bar shows its path
+  await expect(page.locator('.status-bar')).toContainText(join(fixture.root, 'videos', 'big-video.mp4'))
+})
+
+test('toolbar drills into a directory and navigates back up', async () => {
+  await page.locator('g.treemap-node').filter({ hasText: 'photo-a.raw' }).click()
+  await page.getByRole('button', { name: 'Select Parent' }).click()
+  await page.getByRole('button', { name: 'Drill Into' }).click()
+
+  await expect(page.locator('.rootbar-segment--current')).toHaveText('photos')
+  await expect(page.locator('g.treemap-node text', { hasText: 'photo-b.raw' })).toBeVisible()
+  await expect(page.locator('g.treemap-node text', { hasText: 'big-video.mp4' })).toHaveCount(0)
+
+  await page.getByRole('button', { name: 'Up', exact: true }).click()
+  await expect(page.locator('g.treemap-node text', { hasText: 'big-video.mp4' })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Up', exact: true })).toHaveCount(0)
+})
+
+test('right-click opens the context menu, Escape closes it', async () => {
+  await page.locator('g.treemap-node').filter({ hasText: 'big-video.mp4' }).click({ button: 'right' })
+
+  const menu = page.locator('.context-menu')
+  await expect(menu.getByRole('button', { name: 'Reveal in File Manager' })).toBeVisible()
+  // Files get no terminal entry
+  await expect(menu.getByRole('button', { name: 'Open Terminal Here' })).toHaveCount(0)
+
+  await page.keyboard.press('Escape')
+  await expect(menu).toHaveCount(0)
+})

--- a/tests/playwright/tsconfig.json
+++ b/tests/playwright/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.web.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "composite": false,
+    "rootDir": "../.."
+  },
+  "include": ["./**/*"]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -17,6 +17,7 @@
     "src/preload/**/*.d.ts",
     "src/shared/**/*.ts",
     "electron.vite.config.ts",
-    "vitest.config.ts"
+    "vitest.config.ts",
+    "playwright.config.ts"
   ]
 }


### PR DESCRIPTION
Fixes #53

## What

- **7 serial smoke tests** (`tests/playwright/smoke.spec.ts`) driving the **built** Electron app via Playwright's Electron driver, structured as one user journey: boot → preload bridge shape → scan flow → treemap geometry → selection → toolbar drill navigation → context menu.
- **Generated fixture tree** (temp dir, deterministic sizes — nothing committed) scanned by the real scanner; only `dialog.showOpenDialog` is stubbed, inside the main process via `electronApp.evaluate()`.
- **CI job** on `macos-latest` (shipping target, no xvfb) with the Electron binary cached and `npx install-electron` after `npm ci`; failure screenshots upload as artifacts.
- **Workflow renamed** `typecheck.yml` → `ci.yml` ("CI") — it's no longer just typecheck.
- **Opt-in trace recording:** `OOS_E2E_TRACE=1 npm run test:e2e`, then `npx playwright show-trace test-results/smoke-trace.zip` for a step-by-step replay with screenshots and DOM snapshots.
- Docs: CLAUDE.md testing section (incl. flake-budget scope discipline), DESIGN.md decision entry, README test commands.

## Why

The Vitest/jsdom suite tests pieces in isolation; this covers the wiring it can't see — preload contextBridge, main↔renderer IPC round-trips, boot of the built output, real Chromium rendering of the D3 treemap. That's the regression class dependency-bump PRs (#47, #48, #51, #52) introduce while unit tests stay green.

## Scope discipline (flake budget)

Smoke level only, `retries: 0` — flakes should surface, not be retried away. Logic/component coverage stays in Vitest.

## Verification

- e2e suite green on 5 consecutive local runs (~2s each)
- `npm run typecheck` and `npm test` (110 tests) green
- Trace recording verified (zip contains action timeline + 19 screenshots)

Note: the e2e CI job runs for the first time on this very PR — first run is slower while the Electron cache warms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)