### PR TITLE
Add tag-gated CI release workflow: sign, notarize, draft release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ jobs:
   typecheck-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           cache: npm
@@ -21,8 +21,8 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           cache: npm
@@ -33,7 +33,7 @@ jobs:
         run: echo "v=$(node -p "require('./package-lock.json').packages['node_modules/electron'].version")" >> "$GITHUB_OUTPUT"
       # Electron ≥42 no longer downloads its binary via postinstall;
       # install-electron fetches it into this cache explicitly
-      - uses: actions/cache@v6
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/Library/Caches/electron
           key: electron-${{ runner.os }}-${{ steps.electron-version.outputs.v }}
@@ -45,7 +45,7 @@ jobs:
       - run: npm run test:e2e
         env:
           OOS_E2E_TRACE: 1
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:
           name: playwright-results

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,79 @@
+# Release: build, sign, notarize, and draft a GitHub release for a v* tag.
+#
+# Security posture (see issue #55 and docs/RELEASING.md):
+# - Secrets live in the `release` environment, restricted to v* tags with a
+#   required-reviewer gate — PR and branch workflows cannot reach them.
+# - Only GitHub-owned actions, pinned to full commit SHAs; everything else is
+#   plain shell + Apple tools + electron-builder from the lockfile.
+# - No cross-run caching: release runs are rare, and skipping restores removes
+#   cache poisoning as a vector for this privileged workflow.
+
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write # create the draft release + upload artifacts
+
+jobs:
+  release:
+    runs-on: macos-latest
+    environment: release
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24
+      - run: npm ci
+      - run: npx install-electron
+
+      # @electron/notarize expects APPLE_API_KEY to be a *path* to the .p8,
+      # while the secret holds the key's content — write it to the job temp dir.
+      - name: Materialise App Store Connect API key
+        run: printf '%s' "$ASC_KEY_CONTENT" > "$RUNNER_TEMP/asc-key.p8"
+        env:
+          ASC_KEY_CONTENT: ${{ secrets.APPLE_API_KEY }}
+
+      # The repo config keeps `identity: null` so local builds never sign.
+      # Here the CLI overrides it with the qualifier "Developer ID Application"
+      # (no trailing colon — electron-builder rejects full cert-name prefixes),
+      # which matches the one identity electron-builder imports from CSC_LINK
+      # into a temporary keychain it creates and destroys itself.
+      # `-c.mac.notarize=true` then signs (hardened runtime + electron-builder's
+      # default Electron entitlements), notarizes via notarytool, and staples.
+      - name: Build, sign, notarize
+        run: |
+          npx electron-vite build
+          npx electron-builder --mac \
+            -c.buildVersion="$GITHUB_REF_NAME" \
+            -c.mac.identity="Developer ID Application" \
+            -c.mac.notarize=true
+        env:
+          CSC_LINK: ${{ secrets.MAC_CERT_P12 }}
+          CSC_KEY_PASSWORD: ${{ secrets.MAC_CERT_PASSWORD }}
+          APPLE_API_KEY: ${{ runner.temp }}/asc-key.p8
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+
+      - name: Shred API key
+        if: always()
+        run: rm -f "$RUNNER_TEMP/asc-key.p8"
+
+      # Independent verification with Apple's own tools: signature validity,
+      # and Gatekeeper acceptance of the dmg (which requires the notarization
+      # ticket to be stapled and valid).
+      - name: Verify signature and notarization
+        run: |
+          codesign --verify --deep --strict --verbose=2 dist/mac*/*.app
+          spctl -a -t open --context context:primary-signature -vv dist/*.dmg
+
+      - name: Draft GitHub release
+        run: |
+          gh release create "$GITHUB_REF_NAME" dist/*.dmg dist/*.zip \
+            --draft --verify-tag --generate-notes \
+            --title "Out Of Space $GITHUB_REF_NAME"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,12 @@ jobs:
         env:
           ASC_KEY_CONTENT: ${{ secrets.APPLE_API_KEY }}
 
+      # Deliberately does NOT reuse `npm run package` (the local, unsigned
+      # path): keeping the release recipe fully spelled out in this reviewed
+      # file means package.json script changes never silently alter a release
+      # build. The flip side: changes to the local build are NOT mirrored here
+      # automatically — adjust both if both are meant.
+      #
       # The repo config keeps `identity: null` so local builds never sign.
       # Here the CLI overrides it with the qualifier "Developer ID Application"
       # (no trailing colon — electron-builder rejects full cert-name prefixes),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,3 +109,9 @@ We use **GitHub Issues** (via `gh`) as the shared backlog.
 - **Watching a run:** `OOS_E2E_TRACE=1 npm run test:e2e` records a trace; `npx playwright show-trace test-results/smoke-trace.zip` replays it step by step with screenshots and DOM snapshots. For live stepping, `npx playwright test --debug` opens the Inspector (`slowMo` is not supported by the Electron driver).
 - **Flake budget — scope discipline:** this suite stays at smoke level: boot + a few core flows over a deterministic fixture, its only job being "the assembled app works". Logic and component testing belong in Vitest — do not grow this into a second component suite, and keep `retries: 0` so flakes surface as failures to fix rather than being retried away.
 - **Known coupling:** Playwright's Electron driver occasionally lags a new Electron major — if an Electron bump PR fails only in the e2e job, suspect that before a real regression.
+
+## Releasing
+
+- Signed + notarized macOS builds are produced **only in CI**, on `v*` tags, via `.github/workflows/release.yml`. Operator manual (cutting a release, credential inventory by name, revocation drill): `docs/RELEASING.md`. Rationale: issue #55.
+- Local builds intentionally never sign (`identity: null` in `electron-builder.yml`) — don't "fix" this; the release workflow overrides it on the CLI.
+- Workflow hygiene (deliberate, keep it): only GitHub-owned actions pinned to full commit SHAs, no cross-run caching in the release job, secrets only in the tag-restricted `release` environment with required-reviewer approval.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,4 +114,5 @@ We use **GitHub Issues** (via `gh`) as the shared backlog.
 
 - Signed + notarized macOS builds are produced **only in CI**, on `v*` tags, via `.github/workflows/release.yml`. Operator manual (cutting a release, credential inventory by name, revocation drill): `docs/RELEASING.md`. Rationale: issue #55.
 - Local builds intentionally never sign (`identity: null` in `electron-builder.yml`) — don't "fix" this; the release workflow overrides it on the CLI.
+- `npm run package` is the **local, unsigned** path only. The release workflow deliberately does *not* reuse it (it invokes electron-vite/electron-builder directly, so package.json script edits can't silently change release builds). Consequence: the two build invocations do not stay in sync automatically — when touching one, check whether the other needs the same change.
 - Workflow hygiene (deliberate, keep it): only GitHub-owned actions pinned to full commit SHAs, no cross-run caching in the release job, secrets only in the tag-restricted `release` environment with required-reviewer approval.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,66 @@
+# Releasing
+
+How signed, notarized macOS builds are produced for this project — and what to do
+if credentials are ever compromised. Design rationale lives in
+[issue #55](https://github.com/idlinglight/out-of-space/issues/55).
+
+## How it works
+
+Releases are built by [`.github/workflows/release.yml`](../.github/workflows/release.yml),
+triggered by pushing a `v*` tag. The workflow signs with a Developer ID Application
+certificate, notarizes via Apple's `notarytool`, staples the ticket, verifies the
+result with `codesign` and `spctl`, and attaches the dmg + zip to a **draft**
+GitHub release.
+
+Security posture, deliberately boring:
+
+- **Local builds never sign.** `electron-builder.yml` pins `identity: null`; only the
+  release workflow overrides it. The signing key does not live on any dev machine.
+- **Secrets are environment-gated.** All credentials sit in the `release` GitHub
+  Environment, restricted to `v*` tags and gated by a required reviewer — workflows
+  on branches and PRs structurally cannot access them.
+- **Zero third-party actions.** The workflow uses only GitHub-owned actions, pinned
+  to full commit SHAs; the rest is shell, Apple's tools, and electron-builder from
+  the lockfile.
+- **No cross-run caching** in the release job, so cache poisoning is not a vector.
+
+## Cutting a release
+
+1. Bump `version` in `package.json` (+ lockfile: `npm install --package-lock-only`),
+   commit on `main` (via PR as usual).
+2. Tag and push: `git tag vX.Y.Z && git push origin vX.Y.Z`
+3. Approve the pending `release` environment run under **Actions** when prompted.
+4. When the run is green, review the draft release (artifacts + generated notes)
+   under **Releases** and publish it manually.
+
+Nothing else is per-release; the one-time credential setup is described below only
+by shape, not by value.
+
+## Credentials (names only — values live in the `release` environment and a password manager)
+
+| Secret | What it is |
+|---|---|
+| `MAC_CERT_P12` | base64 of the Developer ID Application cert + private key (p12) |
+| `MAC_CERT_PASSWORD` | password of that p12 |
+| `APPLE_API_KEY` | content of the App Store Connect **Team** API key (`.p8`, role: Developer) |
+| `APPLE_API_KEY_ID` | its Key ID |
+| `APPLE_API_ISSUER` | the team's Issuer ID |
+
+Notes: an *Individual* ASC API key cannot notarize — it must be a Team key; the
+"Developer" role is the least-privileged role that can. The `.p8` is downloadable
+exactly once.
+
+## Revocation drill (if a credential leaks or a machine/repo is compromised)
+
+Ideally never needed. Entry points, in order:
+
+1. **Developer ID certificate:** [developer.apple.com/account](https://developer.apple.com/account)
+   → Certificates → select → **Revoke** (Developer ID revocations may route through
+   Apple support — start there). Revoking kills the ability to sign as this identity;
+   already-notarized releases keep working unless Apple revokes their tickets.
+2. **ASC API key:** [appstoreconnect.apple.com](https://appstoreconnect.apple.com)
+   → Users and Access → Integrations → Team Keys → revoke the key.
+3. **GitHub:** delete/rotate all five secrets in the `release` environment; check
+   the Actions run history of the `release` environment for runs you didn't approve.
+4. Recreate cert and key (see issue #55's prerequisite checklist), update secrets,
+   and cut a fresh release if a shipped artifact is in doubt.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -16,6 +16,10 @@ Security posture, deliberately boring:
 
 - **Local builds never sign.** `electron-builder.yml` pins `identity: null`; only the
   release workflow overrides it. The signing key does not live on any dev machine.
+- **`npm run package` is not the release entrypoint.** The workflow invokes
+  electron-vite/electron-builder directly, so package.json script edits cannot
+  silently change what gets signed and shipped. The cost: the local and release
+  build invocations must be kept in sync by hand when either changes.
 - **Secrets are environment-gated.** All credentials sit in the `release` GitHub
   Environment, restricted to `v*` tags and gated by a required reviewer — workflows
   on branches and PRs structurally cannot access them.

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -12,6 +12,8 @@ files:
 asar: true
 mac:
   icon: icon.icon
+  # Local builds never sign; the release workflow overrides this on the CLI
+  # (see .github/workflows/release.yml and docs/RELEASING.md)
   identity: null
   target:
     - dmg


### PR DESCRIPTION
Implements the CI signing/notarization pipeline from #55 (prerequisites A–C from the local checklist are already in place).

## What's here

- **`.github/workflows/release.yml`** — triggered by `v*` tags, runs in the reviewer-gated `release` environment. Signs with the Developer ID cert (`CSC_LINK` → electron-builder's own temp keychain), notarizes + staples via `notarytool` with the ASC Team API key, then independently verifies with `codesign --verify` and `spctl -a -t open`, and creates a **draft** GitHub release (publish manually after review).
- **`ci.yml`** — all actions converted to full-SHA pins, so the repo setting "Require actions to be pinned to a full-length commit SHA" can be enabled *after this merges* (enabling before would fail CI runs).
- **`electron-builder.yml`** — unchanged behaviour; comment documenting that `identity: null` is deliberate and CI overrides it on the CLI (`-c.mac.identity="Developer ID Application"` — a qualifier, not a cert name, so no personal name is hardcoded).
- **`docs/RELEASING.md`** — operator manual: how to cut a release, credential inventory (names only), revocation drill.
- **CLAUDE.md** — Releasing section pointing at the above.

## Design notes

- Zero third-party actions in both workflows; GitHub-owned only, SHA-pinned.
- No cross-run caching in the release job (removes cache poisoning as a vector; release runs are rare so speed doesn't matter).
- `APPLE_API_KEY` secret holds the `.p8` *content*; the workflow writes it to `$RUNNER_TEMP` because `@electron/notarize` expects a file path (verified against the vendored source, the docs are misleading on this).
- arm64-only for now (`macos-latest`); universal/x64 builds can be a follow-up if ever needed.

## Testing

Can only be exercised for real by a tag: after merging, `git tag v0.1.0 && git push origin v0.1.0`, approve the environment run, inspect the draft release. YAML validated locally; signing/notarize semantics verified against the electron-builder 26.8.1 source in `node_modules` rather than docs.

README download section deferred until the first release actually exists (tracked in #55).

Relates to #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)