### PR TITLE
Disable electron-builder's implicit publish-on-tag in the release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,10 +50,12 @@ jobs:
       # into a temporary keychain it creates and destroys itself.
       # `-c.mac.notarize=true` then signs (hardened runtime + electron-builder's
       # default Electron entitlements), notarizes via notarytool, and staples.
+      # `--publish never` disables electron-builder's implicit publish-on-tag —
+      # the draft release is created by the explicit gh step below instead.
       - name: Build, sign, notarize
         run: |
           npx electron-vite build
-          npx electron-builder --mac \
+          npx electron-builder --mac --publish never \
             -c.buildVersion="$GITHUB_REF_NAME" \
             -c.mac.identity="Developer ID Application" \
             -c.mac.notarize=true


### PR DESCRIPTION
First real-world run of the release pipeline (v0.1.0): **signing and notarization succeeded**, dmg + zip built — then electron-builder failed the step with `GitHub Personal Access Token is not set` because of its legacy *implicit publishing triggered by git tag* (announced in the log, deprecated in v27). Publishing isn't its job in this design; the explicit `gh release create` step (which has `GH_TOKEN`) handles it, but never ran because the build step exited 1.

One-flag fix: `--publish never`, plus a comment explaining the split.

After merge: delete and re-push the tag so it points at a commit containing the fix —
```
git push origin :refs/tags/v0.1.0
git tag -fa v0.1.0 -m "Out Of Space 0.1.0" origin/main   # after pulling main
git push origin v0.1.0
```

Relates to #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)