### PR TITLE
Sign, notarize, and staple the dmg itself, not only the app inside

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,9 @@ jobs:
       # into a temporary keychain it creates and destroys itself.
       # `-c.mac.notarize=true` then signs (hardened runtime + electron-builder's
       # default Electron entitlements), notarizes via notarytool, and staples.
+      # Notarization covers the .app only — the dmg wrapper needs its own
+      # signature (`-c.dmg.sign=true`, while electron-builder's temp keychain
+      # still exists) and its own notarization ticket (next step).
       # `--publish never` disables electron-builder's implicit publish-on-tag —
       # the draft release is created by the explicit gh step below instead.
       - name: Build, sign, notarize
@@ -58,10 +61,28 @@ jobs:
           npx electron-builder --mac --publish never \
             -c.buildVersion="$GITHUB_REF_NAME" \
             -c.mac.identity="Developer ID Application" \
-            -c.mac.notarize=true
+            -c.mac.notarize=true \
+            -c.dmg.sign=true
         env:
           CSC_LINK: ${{ secrets.MAC_CERT_P12 }}
           CSC_KEY_PASSWORD: ${{ secrets.MAC_CERT_PASSWORD }}
+          APPLE_API_KEY: ${{ runner.temp }}/asc-key.p8
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+
+      # Tickets are per-artifact: the .app inside is already notarized, but
+      # Gatekeeper assesses the downloaded dmg by its own hash — notarize and
+      # staple it too, so `spctl -t open` accepts it (Apple's recommended
+      # shape for Developer ID dmg distribution).
+      - name: Notarize and staple dmg
+        run: |
+          xcrun notarytool submit dist/*.dmg \
+            --key "$APPLE_API_KEY" \
+            --key-id "$APPLE_API_KEY_ID" \
+            --issuer "$APPLE_API_ISSUER" \
+            --wait
+          xcrun stapler staple dist/*.dmg
+        env:
           APPLE_API_KEY: ${{ runner.temp }}/asc-key.p8
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -8,9 +8,11 @@ if credentials are ever compromised. Design rationale lives in
 
 Releases are built by [`.github/workflows/release.yml`](../.github/workflows/release.yml),
 triggered by pushing a `v*` tag. The workflow signs with a Developer ID Application
-certificate, notarizes via Apple's `notarytool`, staples the ticket, verifies the
-result with `codesign` and `spctl`, and attaches the dmg + zip to a **draft**
-GitHub release.
+certificate and notarizes via Apple's `notarytool` — both the `.app` and the dmg
+that wraps it, since notarization tickets are per-artifact — staples the tickets,
+verifies the result with `codesign` and `spctl`, and attaches the dmg + zip to a
+**draft** GitHub release. (The zip's app carries its stapled ticket inside; zips
+themselves can't be stapled.)
 
 Security posture, deliberately boring:
 


### PR DESCRIPTION
Third iteration of the release pipeline (#55). Run 2 got further than run 1: the `.app` passed `codesign --verify` fully (`satisfies its Designated Requirement`), but `spctl` rejected the dmg with `no usable signature`.

**Root cause:** electron-builder signs and notarizes only the `.app`; the dmg wrapper stays completely plain (`dmg.sign` even defaults to `false`). Notarization tickets are per-artifact — the stapled app inside doesn't make the *dmg* pass a Gatekeeper assessment of the download itself.

**Fix — upgrade the artifact rather than weaken the check:**
- `-c.dmg.sign=true` so electron-builder signs the dmg with the same Developer ID identity (has to happen inside that run, while its temporary keychain exists)
- new step: `xcrun notarytool submit --wait` + `xcrun stapler staple` for the dmg (API-key envs only — no signing keychain needed)
- key shredding moved after the new step; verification step unchanged and now meaningful
- RELEASING.md wording updated (also notes zips can't be stapled — the zip's app carries its ticket inside)

Costs one extra notarization round-trip per release (~1–3 min). The alternative — verifying only the stapled app and shipping a plain dmg — is common in the Electron ecosystem and launches fine for users, but since this pipeline is partly the point of the project, the dmg now matches Apple's recommended Developer ID distribution shape end-to-end.

After merge, same re-tag dance:
```
git push origin :refs/tags/v0.1.0
git tag -fa v0.1.0 -m "Out Of Space 0.1.0"
git push origin v0.1.0
```

Relates to #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)