### PR TITLE
Add Download section to README, tick Phase 4 release goals

### DIFF
--- a/GOALS.md
+++ b/GOALS.md
@@ -38,7 +38,8 @@ High-level goals and progress tracking.
 - [x] App icon and basic branding
 
 ### Phase 4 — Release
-- [ ] macOS packaging (.dmg)
-- [ ] GitHub release with binary
+- [x] macOS packaging (.dmg)
+- [x] Signed + notarized builds via tag-gated CI (issue #55, docs/RELEASING.md)
+- [x] GitHub release with binary (v0.1.0)
 - [ ] README with screenshots and usage instructions
 - [ ] Portfolio-ready state

--- a/README.md
+++ b/README.md
@@ -10,7 +10,13 @@ Built with Electron, Vue 3, and D3.
 
 ## Status
 
-Work in progress — directory scanning, interactive treemap visualisation, and context actions are functional. Packaging remains.
+Work in progress — directory scanning, interactive treemap visualisation, and context actions are functional. Signed and notarized macOS builds are published via Releases.
+
+## Download
+
+Grab the latest dmg from the [Releases page](https://github.com/idlinglight/out-of-space/releases/latest) (macOS, Apple silicon). Builds are code-signed and notarized — both the app and the dmg itself — by a tag-gated CI pipeline; see [docs/RELEASING.md](docs/RELEASING.md) for how releases are produced.
+
+Open the dmg and drag **Out Of Space** to Applications (running it straight from the dmg works too).
 
 ## Getting Started
 


### PR DESCRIPTION
Last task from #55: user-facing download docs, now that the pipeline has produced a verified v0.1.0 draft release.

- README: Download section pointing at `/releases/latest` (goes live when the draft is published), one-line note that builds are signed + notarized with a pointer to `docs/RELEASING.md`; stale "Packaging remains" status line updated.
- GOALS.md: Phase 4 packaging/signing/release items ticked (screenshots + portfolio-ready remain open).

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)