### PR TITLE
Enable Dependabot version updates (npm + github-actions)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,59 @@
+# Dependabot VERSION updates — this file's presence on main is the enable
+# switch; no settings toggle involved. Spec + rationale: issue #60.
+# Pattern deliberately identical across the author's repos (public and
+# private): one set of cadence/guard settings to remember, not several.
+# cooldown mirrors the local npm guard (min-release-age=3 in ~/.npmrc).
+#
+# Deliberately NOT covered here: CVE-driven alerts / security updates are
+# separate repo-settings toggles (dependency graph + Dependabot alerts +
+# Dependabot security updates — all enabled 2026-07-31).
+#
+# ── Review traps for bump PRs in THIS repo ──────────────────────────────
+# * electron-builder: PR CI never exercises the signing/notarization path
+#   (that runs only on v* tags via release.yml). A bump can be green here
+#   and still break the next release build — review with docs/RELEASING.md
+#   in mind, and remember release.yml invokes electron-builder directly
+#   (not via `npm run package`).
+# * electron majors (~every 8 weeks, arrive as solo PRs): Playwright's
+#   Electron driver occasionally lags a new Electron major — if ONLY the
+#   e2e job fails on an Electron bump, suspect that before a real
+#   regression (see CLAUDE.md, "End-to-end").
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Vienna
+    cooldown:
+      default-days: 3
+    open-pull-requests-limit: 5
+    # one weekly PR for all minor+patch bumps; majors arrive individually
+    groups:
+      npm-minor-patch:
+        update-types:
+          - minor
+          - patch
+    ignore:
+      # vue-tsc can't type-check under TS 7.0 (the native/tsgo port);
+      # Vue language-tools support expected around TS 7.1 —
+      # https://github.com/vuejs/language-tools/issues/5381
+      # Range (not the whole major) so 7.1 DOES get proposed when it ships.
+      # Still current as of 2026-07-31 (latest = 7.0.2, 7.1 dev-only).
+      - dependency-name: typescript
+        versions: ["7.0.x"]
+
+  # cooldown is unsupported for github-actions (docs, 2026-07-26) —
+  # weekly cadence + review-before-merge is the age guard here.
+  # Actions are SHA-pinned with version comments; Dependabot bumps both.
+  # NOT Dependabot's territory: node-version in the workflows' setup-node
+  # steps (a `with:` input, not an action version) — that stays manual.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Vienna

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,11 @@ We use **GitHub Issues** (via `gh`) as the shared backlog.
 - **Flake budget — scope discipline:** this suite stays at smoke level: boot + a few core flows over a deterministic fixture, its only job being "the assembled app works". Logic and component testing belong in Vitest — do not grow this into a second component suite, and keep `retries: 0` so flakes surface as failures to fix rather than being retried away.
 - **Known coupling:** Playwright's Electron driver occasionally lags a new Electron major — if an Electron bump PR fails only in the e2e job, suspect that before a real regression.
 
+## Dependency Updates (Dependabot)
+
+- Version updates run via `.github/dependabot.yml` (weekly Monday, grouped minor+patch, majors solo). The file itself documents the **review traps** — electron-builder's untested-in-PR-CI release path, Playwright lagging Electron majors, the TS 7.0.x ignore — read its comments before judging a bump PR. Rationale: issue #60; the pattern is kept deliberately identical across the author's repos.
+- CVE-driven alerts and security updates are separate repo-settings toggles (dependency graph, Dependabot alerts, security updates — all enabled), orthogonal to the YAML.
+
 ## Releasing
 
 - Signed + notarized macOS builds are produced **only in CI**, on `v*` tags, via `.github/workflows/release.yml`. Operator manual (cutting a release, credential inventory by name, revocation drill): `docs/RELEASING.md`. Rationale: issue #55.


### PR DESCRIPTION
Fixes #60

Adds `.github/dependabot.yml`. Cadence and guards are kept deliberately identical across the author's repos (one set of settings to remember):

- **npm**: weekly Monday 06:00 Europe/Vienna, 3-day cooldown (mirrors local `min-release-age`), one grouped PR for minor+patch, majors solo, limit 5, TS `7.0.x` range-ignore (vue-tsc; 7.1 will be proposed when it ships).
- **github-actions**: same weekly cadence; cooldown unsupported there, review-before-merge is the age guard.
- No docker block (nothing container-based here).

Review traps specific to this repo are written as comments **in the config file** so they're at hand when a bump PR needs judgment: electron-builder's release path is never exercised by PR CI (tags only), and Playwright's Electron driver can lag Electron majors. CLAUDE.md gets a short section pointing there.

Repo settings (done outside this PR): dependency graph, Dependabot alerts, Dependabot security updates — all enabled 2026-07-31.

Note: the file takes effect once it lands on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)