### PR TITLE
Ignore vite majors in Dependabot until electron-vite supports them

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,16 @@ updates:
       # Still current as of 2026-07-31 (latest = 7.0.2, 7.1 dev-only).
       - dependency-name: typescript
         versions: ["7.0.x"]
+      # electron-vite (stable) peer-supports only vite ^5 || ^6 || ^7, so a
+      # vite major fails `npm ci` outright with ERESOLVE (PR #69). Support
+      # arrives with electron-vite 6 (beta-only as of 2026-07-31). Whole-major
+      # ignore, unlike the TS range: the unlock is an electron-vite release,
+      # not a vite version. REMOVE this entry when the electron-vite 6 stable
+      # major PR arrives — that PR is the reminder, and the two bumps belong
+      # in one branch since they only install together. Tracker: issue #70.
+      - dependency-name: vite
+        update-types:
+          - version-update:semver-major
 
   # cooldown is unsupported for github-actions (docs, 2026-07-26) —
   # weekly cadence + review-before-merge is the age guard here.


### PR DESCRIPTION
Relates to #70 (stays open as the unlock tracker)

Adds a whole-major `ignore` for `vite` to `.github/dependabot.yml`, following the TS 7.0.x pattern: the trap and its removal condition live as a comment next to the entry. Rationale: electron-vite 5 (stable) peer-supports only vite `^5 || ^6 || ^7`, so #69 failed `npm ci` with `ERESOLVE` — uninstallable, not flaky. Only `6.0.0-beta.x` widens the range to `^8`, and we don't ride betas of the build tool.

Whole-major rather than a `8.x` range on purpose: the unlock is an **electron-vite release**, not a vite version — when the electron-vite 6 stable major PR arrives, remove this entry and take vite 8 in the same branch (they only install together).

vite 7.x minor/patch bumps keep flowing through the weekly group PR. #69 gets closed with a pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)