### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "out-of-space",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "out-of-space",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "out-of-space",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Visualise what's eating your disk space",
   "main": "./out/main/index.js",
   "author": "Florian Scholz",


### PR DESCRIPTION
Patch bump per `docs/RELEASING.md` step 1, to cut `v0.1.1` and validate a signed build end-to-end. Carries the week's merged dependency updates (electron 43.2.0, pinia 4, jsdom 30, vue/vue-router/vitest minors, actions bumps).

After merge: tag `v0.1.1` on main → release workflow runs → environment approval (manual, deliberately) → draft release to review and publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)